### PR TITLE
add artifact hub definition to claim the verified publisher

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 @sigstore/helm-sigstore-codeowners
+
+# The CODEOWNERS are managed via a GitHub team, but the current list is:
+# sabre1041
+# lukehinds

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+repositoryID: d1111d50-35b5-4c43-acbc-bd4ad5407165
+owners:
+  - name: sabre1041
+    email: andy.block@gmail.com
+  - name: lukehinds
+    email: lhinds@redhat.com


### PR DESCRIPTION
#### Summary
- add artifact hub definition to claim the verified publisher
- add codeowners usernames

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
