### PR TITLE
add arm64 to be downloaded when using helm plugin install

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "sigstore"
-version: "0.1.3"
+version: "0.1.4"
 usage: "Integrates Helm into Sigstore"
 description: |-
   This plugin integrates Helm into the Sigstore ecosystem.

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -69,7 +69,7 @@ initOS() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  supported="linux-amd64\ndarwin-amd64\nwindows-amd64"
+  supported="linux-amd64\ndarwin-amd64\nlinux-arm64\ndarwin-arm64\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuild binary for ${OS}-${ARCH}."
     exit 1


### PR DESCRIPTION
#### Summary
add arm64 to be downloaded when using helm plugin install

#### Ticket Link

Fixes #34 

cc @strongjz

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
add arm64 to be downloaded when using helm plugin install
```
