### PR TITLE
Updates go / ci jobs and provenance 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,13 @@
+---
 version: 2
 updates:
-
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: "daily"
-  open-pull-requests-limit: 10
-
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  open-pull-requests-limit: 10
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: 1.19
+          go-version: '1.20'
           check-latest: true
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,13 @@ jobs:
     permissions:
       contents: write # needed to write releases
       id-token: write # needed for keyless signing
+
     runs-on: ubuntu-latest
+
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
+      tag_name: ${{ steps.tag.outputs.tag_name }}
+
     steps:
       - name: Set Go Version
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
@@ -24,7 +28,7 @@ jobs:
           check-latest: true
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
+        uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65 # v3.0.1
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@07978da4bdb4faa726e52dfc6b1bed63d4b56479 # v0.13.3
@@ -38,6 +42,10 @@ jobs:
            source ./scripts/ldflags.sh
            goflags=$(ldflags)
            echo "GO_FLAGS="${goflags}"" >> "$GITHUB_ENV"
+
+      - name: Set tag output
+        id: tag
+        run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
 
       - name: Run GoReleaser
         id: run-goreleaser
@@ -59,32 +67,16 @@ jobs:
           echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
 
   provenance:
-    needs: release
+    needs:
+      - release
+
     permissions:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
+
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.5.0
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
-      upload-assets: false # do not upload to a new release
-
-  release-provenance:
-    needs: [provenance]
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read # To read the workflow path.
-      contents: write # To add assets to a release.
-    steps:
-      - name: Download the provenance
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: ${{needs.provenance.outputs.provenance-name}}
-
-      - name: Release Provenance
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
-        id: release-provenance
-        with:
-          draft: true
-          files: ${{needs.provenance.outputs.provenance-name}}
-
+      upload-assets: true # upload to a new release
+      upload-tag-name: "${{ needs.release.outputs.tag_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set Go Version
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: 1.19
+          go-version: '1.20'
           check-latest: true
 
       - name: Install Cosign

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: 1.19
+  GO_VERSION: '1.20'
 
 jobs:
   license-check:
@@ -43,4 +43,4 @@ jobs:
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         timeout-minutes: 5
         with:
-          version: v1.50.1
+          version: v1.51

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,31 +1,31 @@
 linters:
   enable:
-  - asciicheck
-  - deadcode
-  - depguard
-  - errcheck
-  - errorlint
-  - gofmt
-  - goimports
-  - gosec
-  - gocritic
-  - importas
-  - prealloc
-  - revive
-  - misspell
-  - stylecheck
-  - tparallel
-  - unconvert
-  - unparam
-  - whitespace
+    - asciicheck
+    - depguard
+    - errcheck
+    - errorlint
+    - gofmt
+    - goimports
+    - gosec
+    - gocritic
+    - importas
+    - prealloc
+    - revive
+    - misspell
+    - stylecheck
+    - tparallel
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
 output:
   uniq-by-line: false
 issues:
   exclude-rules:
-  - path: _test\.go
-    linters:
-    - errcheck
-    - gosec
+    - path: _test\.go
+      linters:
+        - errcheck
+        - gosec
   max-issues-per-linter: 0
   max-same-issues: 0
 run:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,73 +1,71 @@
 project_name: helm-sigstore
 
 env:
-- GO111MODULE=on
-- COSIGN_EXPERIMENTAL=true
+  - GO111MODULE=on
+  - COSIGN_YES=true
 
 # Prevents parallel builds from stepping on each others toes downloading modules
 before:
   hooks:
-  - go mod tidy
+    - go mod tidy
 
 gomod:
   proxy: true
 
 builds:
-- binary: helm-sigstore-{{ .Os }}-{{ .Arch }}
-  no_unique_dist_dir: true
-  main: .
-  flags:
-  - -trimpath
-  mod_timestamp: "{{ .CommitTimestamp }}"
-  goos:
-  - linux
-  - windows
-  - darwin
-  goarch:
-  - amd64
-  - arm64
-  - arm
-  - s390x
-  - ppc64le
-  goarm:
-  - "7"
-  ignore:
-  - goos: windows
-    goarch: arm64
-  - goos: windows
-    goarch: arm
-  - goos: windows
-    goarch: s390x
-  - goos: windows
-    goarch: ppc64le
-  ldflags:
-  - "{{ .Env.LDFLAGS }}"
-  env:
-  - CGO_ENABLED=0
+  - binary: helm-sigstore-{{ .Os }}-{{ .Arch }}
+    no_unique_dist_dir: true
+    main: .
+    flags:
+      - -trimpath
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - s390x
+      - ppc64le
+    goarm:
+      - "7"
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: s390x
+      - goos: windows
+        goarch: ppc64le
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"
+    env:
+      - CGO_ENABLED=0
 
 signs:
   # Keyless
-- id: helm-sigstore-keyless
-  signature: "${artifact}.sig"
-  certificate: "${artifact}.pem"
-  env:
-  - COSIGN_EXPERIMENTAL=1
-  cmd: cosign
-  args:
-    - sign-blob
-    - "--output-certificate=${certificate}"
-    - "--output-signature=${signature}"
-    - "${artifact}"
-  artifacts: binary
-  output: true
+  - id: helm-sigstore-keyless
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    cmd: cosign
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: binary
+    output: true
 
 archives:
-- format: binary
-  name_template: "{{ .Binary }}"
-  allow_different_binary_count: true
+  - format: binary
+    name_template: "{{ .Binary }}"
+    allow_different_binary_count: true
 
 sboms:
-- artifacts: binary
+  - artifacts: binary
 
 checksum:
   name_template: "checksums.txt"

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	rm -f $(GOLANGCI_LINT) || :
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.50.0 ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.51.2 ;\
 
 lint: golangci-lint ## Runs golangci-lint linter
 	$(GOLANGCI_LINT) run  -n

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/helm-sigstore
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-openapi/runtime v0.25.0

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "sigstore"
-version: "0.1.7"
+version: "0.2.0"
 usage: "Integrates Helm into Sigstore"
 description: |-
   This plugin integrates Helm into the Sigstore ecosystem.


### PR DESCRIPTION
#### Summary
- upgrade go to 1.20
- format indentation
- refactor provenance to match with the other projects in the org
- bump plugin version to prepare for a new release